### PR TITLE
Prevent duplicate Harmony patches on RecipeWorker.AvailableOnNow

### DIFF
--- a/1.4/Source/HarmonyPatches/RecipeWorker_AvailableOnNow_Patch.cs
+++ b/1.4/Source/HarmonyPatches/RecipeWorker_AvailableOnNow_Patch.cs
@@ -15,7 +15,7 @@ namespace VREAndroids
             yield return typeof(RecipeWorker).GetMethod("AvailableOnNow", AccessTools.all);
             foreach (var type in typeof(RecipeWorker).AllSubclasses())
             {
-                var method = type.GetMethod("AvailableOnNow", AccessTools.all);
+                var method = type.GetMethod("AvailableOnNow", AccessTools.allDeclared);
                 if (method != null)
                 {
                     yield return method;


### PR DESCRIPTION
The change is calling the `GetMethod` method with `AccessTools.allDeclared` instead of `AccessTools.all`.

This ensure the result of the call will only return the method if the class itself declares the method itself, instead of returning its parent's method if it didn't declare it.

Below I've included text files where I've copied a fragment of Hugslib log, specifically I've only included the patches on `RecipeWorker.AvailableOnNow` and its subclasses both before and after the change I've made.
[PatchesBefore.txt](https://github.com/Vanilla-Expanded/VanillaRacesExpanded-Android/files/12322104/PatchesBefore.txt)
[PatchesAfter.txt](https://github.com/Vanilla-Expanded/VanillaRacesExpanded-Android/files/12322107/PatchesAfter.txt)