### PR TITLE
Fix compatibility issues due to ModsConfig.IsActive

### DIFF
--- a/1.4/Source/HarmonyPatches/CompAbilityEffect_BloodfeederBite_Valid_Patch.cs
+++ b/1.4/Source/HarmonyPatches/CompAbilityEffect_BloodfeederBite_Valid_Patch.cs
@@ -9,7 +9,7 @@ namespace VREAndroids
     [HarmonyPatch]
     public static class CompAbilityEffect_BloodfeederBite_Valid_Patch
     {
-        public static bool VanillaRacesExpandedSanguophageActive = ModsConfig.IsActive("vanillaracesexpanded.sanguophage");
+        public static bool VanillaRacesExpandedSanguophageActive = ModsConfig.IsActive("vanillaracesexpanded.sanguophage") || ModsConfig.IsActive("vanillaracesexpanded.sanguophage_steam");
         
         [HarmonyTargetMethods]
         public static IEnumerable<MethodBase> TargetMethods()

--- a/1.4/Source/Utilities/ModCompatibility.cs
+++ b/1.4/Source/Utilities/ModCompatibility.cs
@@ -8,9 +8,9 @@ namespace VREAndroids
     [StaticConstructorOnStartup]
     public static class ModCompatibility
     {
-        public static bool DubsMintMenusActive = ModsConfig.IsActive("Dubwise.DubsMintMenus");
-        public static bool SnapOutActive = ModsConfig.IsActive("weilbyte.snapout");
-        public static bool MSE2Active = ModsConfig.IsActive("MSE2.Core");
+        public static bool DubsMintMenusActive = ModsConfig.IsActive("Dubwise.DubsMintMenus") || ModsConfig.IsActive("Dubwise.DubsMintMenus_steam");
+        public static bool SnapOutActive = ModsConfig.IsActive("weilbyte.snapout") || ModsConfig.IsActive("weilbyte.snapout_steam");
+        public static bool MSE2Active = ModsConfig.IsActive("MSE2.Core") || ModsConfig.IsActive("MSE2.Core_steam");
         public static Type ignoreSubPartsExtensionType;
         static ModCompatibility()
         {


### PR DESCRIPTION
The issue occurs when checking if a mod is active with `ModsConfig.IsActive` when running the workshop version of a mod while there's a local copy in the mods directory. In those cases the `ModsConfig.IsActive` will return false as the running mod will have the `_steam` postfix.

The simple fix is to simply check for mod ID, as well as the mod ID with the `_steam` postfix.

For related PRs, check:
Vanilla-Expanded/VanillaExpandedFramework#72