### PR TITLE
Update TaleUtility_Notify_PawnDied.cs to prevent NRE for non-ideology players

### DIFF
--- a/1.5/Source/HarmonyPatches/Precepts/TaleUtility_Notify_PawnDied.cs
+++ b/1.5/Source/HarmonyPatches/Precepts/TaleUtility_Notify_PawnDied.cs
@@ -11,7 +11,7 @@ namespace VREAndroids
     {
         public static void Postfix(Pawn victim, DamageInfo? dinfo)
         {
-            if (Utils.IsAndroid(victim)) {
+            if (ModsConfig.IdeologyActive && Utils.IsAndroid(victim)) {
 
                 Pawn pawn = dinfo?.Instigator as Pawn;
                 if (pawn != null)


### PR DESCRIPTION
Fix: Ideology check

VREA_DefOf.VRE_AndroidDied has [MayRequireIdeology], but the patch requiring it does not.
This causes NullReferenceException for players without ideology whenever an Android is killed.
Checking IdeologyActive before going for an operation should fix this issue.

Changes: 
-Add ModsConfig.IdeologyActive check for TaleUtility_Notify_PawnDied_Patch_Patch