### PR TITLE
Add tox gas immunity to Synthetic Immunity gene.

### DIFF
--- a/1.6/Defs/GeneDefs/GeneDefs.xml
+++ b/1.6/Defs/GeneDefs/GeneDefs.xml
@@ -200,6 +200,7 @@
 			<ToxicResistance>1</ToxicResistance>
 			<ToxicEnvironmentResistance>1</ToxicEnvironmentResistance>
 		</statOffsets>
+		<immuneToToxGasExposure>true</immuneToToxGasExposure>
 	</VREAndroids.AndroidGeneDef>
 
 	<VREAndroids.AndroidGeneDef ParentName="VREA_HardwareBase">


### PR DESCRIPTION
Hi, the synthetic immunity gene states:

> They will also not suffer from toxic buildup, and are _**immune to the effects of tox gas**_

However, they are not immune to the Tox gas hediff, only the tox buildup. Someone wanted me to add this in a fix in my submod, but I figured it would be better to open the fix as a PR. If this is intended behavior, apologies.

Before:
<img width="1405" height="839" alt="before" src="https://github.com/user-attachments/assets/18cdaae6-e1d7-42ad-b020-0676a49763ce" />


After:
<img width="1705" height="1085" alt="after" src="https://github.com/user-attachments/assets/62ec6340-9ab8-4715-920e-aac76d4ecc0c" />
